### PR TITLE
Smooth transition between screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -49,3 +49,19 @@ body {
 .leader-line {
     transition: all 0.3s ease-in-out;
 }
+
+/* Animaciones de transición entre pantallas */
+.fade-enter {
+    opacity: 0;
+}
+.fade-enter-active {
+    opacity: 1;
+    transition: opacity 0.5s ease-in-out;
+}
+.fade-exit {
+    opacity: 1;
+}
+.fade-exit-active {
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -21,9 +21,29 @@ scoreEl.textContent = `Puntos: ${score}`;
         const totalLevels = 2;
 
         function showScreen(screenId) {
-            screens.forEach(screen => {
-                screen.classList.toggle('active', screen.id === screenId);
-            });
+            if (currentScreen === screenId) return;
+
+            const newScreen = document.getElementById(screenId);
+            const oldScreen = document.getElementById(currentScreen);
+
+            if (oldScreen) {
+                oldScreen.classList.add('fade-exit');
+                requestAnimationFrame(() => oldScreen.classList.add('fade-exit-active'));
+                oldScreen.addEventListener('transitionend', function handler() {
+                    oldScreen.classList.remove('fade-exit', 'fade-exit-active', 'active');
+                    oldScreen.removeEventListener('transitionend', handler);
+                });
+            }
+
+            if (newScreen) {
+                newScreen.classList.add('active', 'fade-enter');
+                requestAnimationFrame(() => newScreen.classList.add('fade-enter-active'));
+                newScreen.addEventListener('transitionend', function handler() {
+                    newScreen.classList.remove('fade-enter', 'fade-enter-active');
+                    newScreen.removeEventListener('transitionend', handler);
+                });
+            }
+
             currentScreen = screenId;
             updateProgressBar();
         }


### PR DESCRIPTION
## Summary
- add fade in/out classes for switching screens
- animate screen changes with new classes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd3c20a88326abfbf339af4ae7e9