### PR TITLE
Add final score display and progress reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,15 @@
             <p class="text-gray-600 mb-6">
                 Has completado todos los retos y ahora tienes una mejor comprensión del Storytelling Digital.
             </p>
-            <button id="restart-btn" class="w-full md:w-auto px-8 py-3 bg-gray-800 text-white font-semibold rounded-lg shadow-md hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-700 focus:ring-opacity-50 transition-transform transform hover:scale-105">
-                Volver a Jugar
-            </button>
+            <p id="final-score" class="font-semibold mb-6"></p>
+            <div class="flex flex-col space-y-4">
+                <button id="restart-btn" class="w-full md:w-auto px-8 py-3 bg-gray-800 text-white font-semibold rounded-lg shadow-md hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-700 focus:ring-opacity-50 transition-transform transform hover:scale-105">
+                    Volver a Jugar
+                </button>
+                <button id="clear-progress-btn" class="w-full md:w-auto px-8 py-3 bg-red-600 text-white font-semibold rounded-lg shadow-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-opacity-50 transition-transform transform hover:scale-105">
+                    Borrar progreso
+                </button>
+            </div>
         </div>
 
     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -3,6 +3,7 @@
         const progressBar = document.getElementById('progress-bar');
 const scoreEl = document.getElementById("score");
 const badgesEl = document.getElementById("badges");
+const finalScoreEl = document.getElementById("final-score");
 let score = parseInt(localStorage.getItem("score") || "0");
 function updateScore(points){
     score += points;
@@ -25,6 +26,9 @@ scoreEl.textContent = `Puntos: ${score}`;
                 screen.classList.toggle('active', screen.id === screenId);
             });
             currentScreen = screenId;
+            if(screenId === 'final-screen' && finalScoreEl){
+                finalScoreEl.textContent = `Puntuaci\u00f3n final: ${score}`;
+            }
             updateProgressBar();
         }
         
@@ -290,10 +294,20 @@ let level2Attempts = 0;
             });
             document.getElementById('draggable-options').innerHTML = '';
             document.getElementById('level2-feedback').textContent = '';
-            
+
             // Volver a la pantalla de bienvenida
             showScreen('welcome-screen');
         });
+
+        const clearBtn = document.getElementById('clear-progress-btn');
+        if(clearBtn){
+            clearBtn.addEventListener('click', () => {
+                localStorage.removeItem('score');
+                score = 0;
+                scoreEl.textContent = `Puntos: ${score}`;
+                showScreen('welcome-screen');
+            });
+        }
 
         // Iniciar la aplicación
         showScreen('welcome-screen');


### PR DESCRIPTION
## Summary
- display final score on the last screen
- when showing the final screen, insert the score value
- allow clearing stored score via **Borrar progreso** button

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd3dd2908326b6f324fdcaba8b38