### PR TITLE
Implement fade transitions for screen changes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -68,3 +68,18 @@ body {
     outline: none;
     box-shadow: 0 0 0 2px rgba(55, 65, 81, 0.5);
 }
+/* Transiciones de desvanecimiento */
+.fade-enter {
+    opacity: 0;
+}
+.fade-enter-active {
+    opacity: 1;
+    transition: opacity 0.5s ease-in-out;
+}
+.fade-exit {
+    opacity: 1;
+}
+.fade-exit-active {
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -21,9 +21,29 @@ scoreEl.textContent = `Puntos: ${score}`;
         const totalLevels = 2;
 
         function showScreen(screenId) {
-            screens.forEach(screen => {
-                screen.classList.toggle('active', screen.id === screenId);
-            });
+            const newScreen = document.getElementById(screenId);
+            const current = document.querySelector('.screen.active');
+
+            if (current && current !== newScreen) {
+                current.classList.add('fade-exit');
+                void current.offsetWidth;
+                current.classList.add('fade-exit-active');
+                current.addEventListener('transitionend', function handler() {
+                    current.classList.remove('active', 'fade-exit', 'fade-exit-active');
+                    current.removeEventListener('transitionend', handler);
+                });
+            }
+
+            if (!newScreen.classList.contains('active')) {
+                newScreen.classList.add('active', 'fade-enter');
+                void newScreen.offsetWidth;
+                newScreen.classList.add('fade-enter-active');
+                newScreen.addEventListener('transitionend', function handler() {
+                    newScreen.classList.remove('fade-enter', 'fade-enter-active');
+                    newScreen.removeEventListener('transitionend', handler);
+                });
+            }
+
             currentScreen = screenId;
             updateProgressBar();
         }


### PR DESCRIPTION
## Summary
- add fade transition classes
- apply fade transitions in `showScreen` for smooth screen changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866debcd11883269e31d7e35b4f5493