### PR TITLE
Add side navigation for level selection

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -108,3 +108,34 @@ body {
 .vibrant-btn:hover::after {
     left: 100%;
 }
+
+/* Navegación lateral */
+#level-navigation {
+    min-width: 60px;
+}
+
+.neon-player {
+    background: radial-gradient(circle, #0ff, #f0f);
+    box-shadow: 0 0 8px #0ff, 0 0 16px #f0f;
+}
+
+.level-btn {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid #000;
+    background-color: #ffffff;
+    font-weight: 700;
+}
+
+.level-btn.active {
+    box-shadow: 0 0 0 2px #ff0066;
+}
+
+.level-btn.locked {
+    background-color: #d1d5db;
+    color: #6b7280;
+    cursor: not-allowed;
+}

--- a/index.html
+++ b/index.html
@@ -12,7 +12,15 @@
 </head>
 <body class="bg-white text-gray-800 flex items-center justify-center min-h-screen p-4">
 
-    <div class="main-container w-full">
+    <div class="flex w-full max-w-screen-lg">
+        <nav id="level-navigation" class="flex flex-col items-center space-y-4 mr-6">
+            <div id="player-icon" class="w-10 h-10 rounded-full neon-player"></div>
+            <button class="level-btn" data-target="welcome-screen">I</button>
+            <button class="level-btn" data-target="level-1">1</button>
+            <button class="level-btn" data-target="level-2">2</button>
+        </nav>
+
+        <div class="main-container w-full">
         <!-- Barra de Progreso -->
         <div class="flex justify-between items-center mb-4">
             <div class="flex items-center space-x-2">
@@ -100,6 +108,7 @@
             </button>
         </div>
 
+        </div>
     </div>
 
     <script src="js/script.js"></script>

--- a/js/script.js
+++ b/js/script.js
@@ -4,6 +4,11 @@
 const scoreEl = document.getElementById("score");
 const badgesEl = document.getElementById("badges");
 let score = parseInt(localStorage.getItem("score") || "0");
+const unlockedLevels = {
+    'welcome-screen': true,
+    'level-1': false,
+    'level-2': false
+};
 function updateScore(points){
     score += points;
     scoreEl.textContent = `Puntos: ${score}`;
@@ -46,20 +51,54 @@ scoreEl.textContent = `Puntos: ${score}`;
 
             currentScreen = screenId;
             updateProgressBar();
+            updateNavigation();
         }
         
-        function updateProgressBar() {
-            let progress = 0;
-            if (currentScreen === 'level-1') progress = 0;
-            if (currentScreen === 'level-2') progress = 50;
-            if (currentScreen === 'final-screen') progress = 100;
-            progressBar.style.width = `${progress}%`;
-        }
+function updateProgressBar() {
+    let progress = 0;
+    if (currentScreen === 'level-1') progress = 0;
+    if (currentScreen === 'level-2') progress = 50;
+    if (currentScreen === 'final-screen') progress = 100;
+    progressBar.style.width = `${progress}%`;
+}
 
-        document.getElementById('start-btn').addEventListener('click', () => {
-            showScreen('level-1');
+function updateNavigation() {
+    document.querySelectorAll('.level-btn').forEach(btn => {
+        const target = btn.dataset.target;
+        if (unlockedLevels[target]) {
+            btn.classList.remove('locked');
+            btn.disabled = false;
+        } else {
+            btn.classList.add('locked');
+            btn.disabled = true;
+        }
+        if (currentScreen === target) {
+            btn.classList.add('active');
+        } else {
+            btn.classList.remove('active');
+        }
+    });
+}
+
+document.querySelectorAll('.level-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const target = btn.dataset.target;
+        if (!unlockedLevels[target]) return;
+        if (target === 'level-1') {
             initLevel1();
-        });
+        }
+        if (target === 'level-2') {
+            initLevel2();
+        }
+        showScreen(target);
+    });
+});
+
+document.getElementById('start-btn').addEventListener('click', () => {
+    unlockedLevels['level-1'] = true;
+    showScreen('level-1');
+    initLevel1();
+});
 
         // --- LÓGICA DEL NIVEL 1: UNIR CONCEPTOS ---
         const level1Data = {
@@ -169,11 +208,12 @@ let level2Attempts = 0;
             document.getElementById('level1-feedback').textContent = '';
         }
 
-        document.getElementById('level1-continue-btn').addEventListener('click', () => {
-            cleanupLevel1Lines(); // <-- CORRECCIÓN: Limpiar las líneas antes de continuar
-            showScreen('level-2');
-            initLevel2();
-        });
+document.getElementById('level1-continue-btn').addEventListener('click', () => {
+    cleanupLevel1Lines(); // <-- CORRECCIÓN: Limpiar las líneas antes de continuar
+    unlockedLevels['level-2'] = true;
+    showScreen('level-2');
+    initLevel2();
+});
         
         // --- LÓGICA DEL NIVEL 2: ARRASTRAR Y SOLTAR ---
         const level2Data = {
@@ -336,7 +376,7 @@ let level2Attempts = 0;
         });
 
         // --- PANTALLA FINAL Y REINICIO ---
-        document.getElementById('restart-btn').addEventListener('click', () => {
+document.getElementById('restart-btn').addEventListener('click', () => {
             // Resetear estado del Nivel 1
             resetLevel1();
             document.getElementById('level1-continue-btn').disabled = true;
@@ -351,8 +391,10 @@ let level2Attempts = 0;
             document.getElementById('level2-feedback').textContent = '';
             
             // Volver a la pantalla de bienvenida
-            showScreen('welcome-screen');
-        });
+    unlockedLevels['level-1'] = false;
+    unlockedLevels['level-2'] = false;
+    showScreen('welcome-screen');
+});
 
         document.getElementById('reset-score-btn').addEventListener('click', () => {
             score = 0;


### PR DESCRIPTION
## Summary
- add sidebar with neon player icon and level buttons
- style sidebar navigation and buttons
- track unlocked levels in script and highlight current
- unlock levels as the user progresses
- reset level access on restart

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866e245f89c8326b32e069724876fec