### PR TITLE
Add true/false quiz level

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             <button class="level-btn" data-target="welcome-screen">I</button>
             <button class="level-btn" data-target="level-1">1</button>
             <button class="level-btn" data-target="level-2">2</button>
+            <button class="level-btn" data-target="level-3">3</button>
         </nav>
 
         <div class="main-container w-full">
@@ -98,6 +99,20 @@
              <div id="level2-feedback" role="alert" class="mt-4 text-center font-medium"></div>
             <div class="text-center mt-8">
                  <button id="level2-check-btn" aria-label="Comprobar respuestas" class="w-full md:w-auto px-8 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-gray-700 focus:ring-opacity-50 transition-transform transform hover:scale-105 vibrant-btn">
+                    Comprobar
+                </button>
+            </div>
+        </div>
+
+        <!-- Nivel 3: Verdadero o Falso -->
+        <div id="level-3" class="screen p-6 bg-white rounded-xl shadow-md">
+            <h2 class="text-2xl font-bold text-center mb-2 text-gray-900">Nivel 3: Verdadero o Falso</h2>
+            <p class="text-center text-gray-600 mb-4">Responde antes de que se acabe el tiempo.</p>
+            <div id="level3-timer" class="text-center font-semibold mb-4"></div>
+            <div id="level3-questions" class="space-y-4"></div>
+            <div id="level3-feedback" role="alert" class="mt-4 text-center font-medium"></div>
+            <div class="text-center mt-8">
+                <button id="level3-check-btn" aria-label="Comprobar respuestas" class="w-full md:w-auto px-8 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-gray-700 focus:ring-opacity-50 transition-transform transform hover:scale-105 vibrant-btn">
                     Comprobar
                 </button>
             </div>


### PR DESCRIPTION
## Summary
- include a button for navigating to a new level
- add level 3 with a timed true/false quiz
- track third level in game logic and progress bar
- reset level 3 state when restarting the game

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866f26e1d908326ab2ab47c208ada31