### PR TITLE
Add level 4 and new end sound

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
             <button class="level-btn" data-target="level-1">1</button>
             <button class="level-btn" data-target="level-2">2</button>
             <button class="level-btn" data-target="level-3">3</button>
+            <button class="level-btn" data-target="level-4">4</button>
         </nav>
 
         <div class="main-container w-full">
@@ -117,7 +118,20 @@
                 </button>
             </div>
         </div>
-        
+
+        <!-- Nivel 4: Quiz Final -->
+        <div id="level-4" class="screen p-6 bg-white rounded-xl shadow-md">
+            <h2 class="text-2xl font-bold text-center mb-2 text-gray-900">Nivel 4: Quiz Final</h2>
+            <p class="text-center text-gray-600 mb-4">Selecciona la respuesta correcta en cada caso.</p>
+            <div id="level4-questions" class="space-y-4"></div>
+            <div id="level4-feedback" role="alert" class="mt-4 text-center font-medium"></div>
+            <div class="text-center mt-8">
+                <button id="level4-check-btn" aria-label="Comprobar respuestas" class="w-full md:w-auto px-8 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-gray-700 focus:ring-opacity-50 transition-transform transform hover:scale-105 vibrant-btn">
+                    Comprobar
+                </button>
+            </div>
+        </div>
+
         <!-- Pantalla Final -->
         <div id="final-screen" class="screen text-center p-6 bg-white rounded-xl shadow-md">
             <h1 class="text-3xl font-bold mb-4 text-green-600">¡Felicidades!</h1>

--- a/js/script.js
+++ b/js/script.js
@@ -9,7 +9,8 @@ const unlockedLevels = {
     'welcome-screen': true,
     'level-1': false,
     'level-2': false,
-    'level-3': false
+    'level-3': false,
+    'level-4': false
 };
 
 // --- SONIDOS ---
@@ -17,7 +18,7 @@ const clickSound = new Audio('https://s3.amazonaws.com/freecodecamp/drums/Cev_H2
 const startSound = new Audio('https://s3.amazonaws.com/freecodecamp/drums/RP4_KICK_1.mp3');
 const successSound = new Audio('https://s3.amazonaws.com/freecodecamp/drums/Heater-1.mp3');
 const failSound = new Audio('https://s3.amazonaws.com/freecodecamp/drums/Dsc_Oh.mp3');
-const beepSound = new Audio('https://cdn.freecodecamp.org/testable-projects-fcc/audio/BeepSound.wav');
+const beepSound = new Audio('https://s3.amazonaws.com/freecodecamp/drums/Chord_1.mp3');
 clickSound.volume = 0.5;
 startSound.volume = 0.5;
 successSound.volume = 0.5;
@@ -48,7 +49,7 @@ scoreEl.textContent = `Puntos: ${score}`;
 
         
         let currentScreen = 'start-screen';
-        const totalLevels = 3;
+        const totalLevels = 4;
 
         function showScreen(screenId) {
             const newScreen = document.getElementById(screenId);
@@ -85,8 +86,9 @@ scoreEl.textContent = `Puntos: ${score}`;
 function updateProgressBar() {
     let progress = 0;
     if (currentScreen === 'level-1') progress = 0;
-    if (currentScreen === 'level-2') progress = 33;
-    if (currentScreen === 'level-3') progress = 66;
+    if (currentScreen === 'level-2') progress = 25;
+    if (currentScreen === 'level-3') progress = 50;
+    if (currentScreen === 'level-4') progress = 75;
     if (currentScreen === 'final-screen') progress = 100;
     progressBar.style.width = `${progress}%`;
 }
@@ -121,6 +123,9 @@ document.querySelectorAll('.level-btn').forEach(btn => {
         }
         if (target === 'level-3') {
             initLevel3();
+        }
+        if (target === 'level-4') {
+            initLevel4();
         }
         showScreen(target);
         playSound(startSound);
@@ -512,6 +517,94 @@ document.getElementById('level1-continue-btn').addEventListener('click', () => {
                 updateScore(50);
                 awardBadge();
                 playSound(successSound);
+                unlockedLevels['level-4'] = true;
+                setTimeout(() => { showScreen('level-4'); initLevel4(); }, 1500);
+            } else {
+                feedbackEl.textContent = 'Hay respuestas incorrectas.';
+                feedbackEl.className = 'mt-4 text-center font-medium text-red-600';
+                playSound(failSound);
+            }
+        });
+
+        // --- LÓGICA DEL NIVEL 4: QUIZ FINAL ---
+        const level4Data = [
+            {
+                id: 'm1',
+                text: '¿Cuál es el principal objetivo del Storytelling Digital?',
+                options: [
+                    'Conectar emocionalmente con la audiencia',
+                    'Vender productos inmediatamente',
+                    'Publicar sin planificación'
+                ],
+                answer: 0
+            },
+            {
+                id: 'm2',
+                text: '¿Qué formato facilita más la interacción?',
+                options: [
+                    'Video interactivo',
+                    'Infografía estática',
+                    'Carta impresa'
+                ],
+                answer: 0
+            },
+            {
+                id: 'm3',
+                text: 'Para mantener la atención del usuario es útil...',
+                options: [
+                    'Usar narrativa coherente y elementos visuales',
+                    'Texto largo sin imágenes',
+                    'Cambiar de tema constantemente'
+                ],
+                answer: 0
+            }
+        ];
+
+        function initLevel4() {
+            const container = document.getElementById('level4-questions');
+            const feedbackEl = document.getElementById('level4-feedback');
+            document.getElementById('level4-check-btn').disabled = false;
+            container.innerHTML = '';
+            feedbackEl.textContent = '';
+
+            level4Data.forEach(q => {
+                let optionsHtml = '';
+                q.options.forEach((opt, idx) => {
+                    optionsHtml += `<label class="block"><input type="radio" name="${q.id}" value="${idx}" class="mr-2">${opt}</label>`;
+                });
+                container.innerHTML += `<div class="space-y-2"><p class="font-medium">${q.text}</p>${optionsHtml}</div>`;
+            });
+        }
+
+        document.getElementById('level4-check-btn').addEventListener('click', () => {
+            const feedbackEl = document.getElementById('level4-feedback');
+            let allAnswered = true;
+            let allCorrect = true;
+
+            level4Data.forEach(q => {
+                const selected = document.querySelector(`input[name="${q.id}"]:checked`);
+                if (!selected) {
+                    allAnswered = false;
+                    allCorrect = false;
+                    return;
+                }
+                if (parseInt(selected.value) !== q.answer) {
+                    allCorrect = false;
+                }
+            });
+
+            if (!allAnswered) {
+                feedbackEl.textContent = 'Responde todas las preguntas.';
+                feedbackEl.className = 'mt-4 text-center font-medium text-red-600';
+                return;
+            }
+
+            if (allCorrect) {
+                feedbackEl.textContent = '¡Genial! Has completado el quiz.';
+                feedbackEl.className = 'mt-4 text-center font-medium text-green-600';
+                updateScore(50);
+                awardBadge();
+                playSound(successSound);
                 setTimeout(() => showScreen('final-screen'), 1500);
             } else {
                 feedbackEl.textContent = 'Hay respuestas incorrectas.';
@@ -542,10 +635,16 @@ document.getElementById('restart-btn').addEventListener('click', () => {
             document.getElementById('level3-timer').textContent = '';
             document.getElementById('level3-check-btn').disabled = false;
 
+            // Resetear estado del Nivel 4
+            document.getElementById('level4-questions').innerHTML = '';
+            document.getElementById('level4-feedback').textContent = '';
+            document.getElementById('level4-check-btn').disabled = false;
+
             // Volver a la pantalla de bienvenida
     unlockedLevels['level-1'] = false;
     unlockedLevels['level-2'] = false;
     unlockedLevels['level-3'] = false;
+    unlockedLevels['level-4'] = false;
     showScreen('start-screen');
     playSound(startSound);
 });


### PR DESCRIPTION
## Summary
- add a new "Nivel 4" quiz section
- update navigation to include the new level
- unlock level 4 after completing level 3
- change final victory sound to a softer chord
- reset level 4 state when restarting game
- adjust progress bar logic for four levels

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866fdd3fd1083269c70715a07abbfa8